### PR TITLE
fix: sorting problem while string with the same of starting

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     if: "contains(github.event.head_commit.message, 'release')"
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: "contains(github.event.commits[0].message, 'release')"
+    if: "contains(github.event.head_commit.message, 'release')"
 
     strategy:
       matrix:

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@
 /build
 /.cache
 /node_modules
+package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.0.16 (Jul 10, 2021)
+
+- Fix sorting problem while string with the same of starting [#5](https://github.com/chen86860/vscode-extension-json-sorter/issues/5)
+
 ### 0.0.14 (Apr 9, 2020)
 
 - Add File type(`JSON/JSONC`) checking

--- a/src/jsonSorter.ts
+++ b/src/jsonSorter.ts
@@ -17,7 +17,27 @@ const sorter = (json: string, desc?: boolean): object => {
     const data = JSON5.parse(json)
     const result = Object.keys(data)
       .map((key) => key)
-      .sort((a, b) => (a.charCodeAt(0) - b.charCodeAt(0)) * (desc ? -1 : 1))
+      .sort((a, b) => {
+        const seed = desc ? -1 : 1
+
+        let chartIndex = 0
+        let diffOfCharCode = a.charCodeAt(chartIndex) - b.charCodeAt(chartIndex)
+        while (diffOfCharCode === 0) {
+          chartIndex += 1
+          if (Number.isNaN(a.charCodeAt(chartIndex))) {
+            diffOfCharCode = -1
+            break
+          }
+          if (Number.isNaN(b.charCodeAt(chartIndex))) {
+            diffOfCharCode = 1
+            break
+          }
+          diffOfCharCode = a.charCodeAt(chartIndex) - b.charCodeAt(chartIndex)
+          if (diffOfCharCode !== 0) break
+        }
+
+        return seed * diffOfCharCode
+      })
       .reduce((prev: any, curr: any) => {
         const key = curr
         const value = data[key]


### PR DESCRIPTION
fix sorting problem while string with the same of starting [#5](https://github.com/chen86860/vscode-extension-json-sorter/issues/5)